### PR TITLE
Fix: remove app in VA will remove the following one as well

### DIFF
--- a/VirtualApp/app/src/main/java/io/virtualapp/home/HomeActivity.java
+++ b/VirtualApp/app/src/main/java/io/virtualapp/home/HomeActivity.java
@@ -75,10 +75,10 @@ public class HomeActivity extends VActivity implements HomeContract.HomeView {
 		mExplosionField = ExplosionField.attachToWindow(this);
 		mPagerView.setOnDragChangeListener(mPresenter::dragChange);
 		mPagerView.setOnEnterCrashListener(mPresenter::dragNearCrash);
-		mPagerView.setOnCrashItemListener((position, consumer) -> {
+		mPagerView.setOnCrashItemListener(position -> {
 			AppModel model = mAdapter.getItem(position);
 			View v = mPagerView.getChildAt(position);
-			mExplosionField.explode(v, view -> consumer.moveToCrash());
+			mExplosionField.explode(v, null);
 			mPresenter.deleteApp(model);
 		});
 		mPagerView.setOnItemClickListener((item, pos) -> {

--- a/VirtualApp/app/src/main/java/io/virtualapp/widgets/PagerView.java
+++ b/VirtualApp/app/src/main/java/io/virtualapp/widgets/PagerView.java
@@ -311,10 +311,7 @@ public class PagerView extends ViewGroup implements PagerAdapter.OnDataChangeLis
 
 				if (isUnderBottomLine) {
 					if (onCrashItemListener != null) {
-						onCrashItemListener.onCrash(dragPosition, () -> {
-							removeViewAt(dragPosition);
-							mAdapter.delete(dragPosition);
-						});
+						onCrashItemListener.onCrash(dragPosition);
 					}
 					isUnderBottomLine = false;
 				}
@@ -881,15 +878,11 @@ public class PagerView extends ViewGroup implements PagerAdapter.OnDataChangeLis
 	}
 
 	public interface OnCrashItemListener {
-		void onCrash(int position, CrashConsumer consumer);
+		void onCrash(int position);
 	}
 
 	public interface OnItemClickListener<DataItem> {
 		void onClick(DataItem item, int pos);
-	}
-
-	public interface CrashConsumer {
-		void moveToCrash();
 	}
 
 	// 使用Map集合记录，防止动画执行混乱

--- a/VirtualApp/lib/src/main/java/com/lody/virtual/service/pm/VAppManagerService.java
+++ b/VirtualApp/lib/src/main/java/com/lody/virtual/service/pm/VAppManagerService.java
@@ -204,11 +204,16 @@ public class VAppManagerService extends IAppManager.Stub {
 	public boolean uninstallApp(String pkg) {
 		synchronized (PackageCache.sPackageCaches) {
 			if (isAppInstalled(pkg)) {
-				VActivityManagerService.getService().killAppByPkg(pkg, VUserHandle.USER_ALL);
-				FileUtils.deleteDir(VEnvironment.getDataAppPackageDirectory(pkg));
-				PackageCache.remove(pkg);
-				mBroadcastSystem.stopApp(pkg);
-				notifyAppUninstalled(pkg);
+				try {
+					VActivityManagerService.getService().killAppByPkg(pkg, VUserHandle.USER_ALL);
+					FileUtils.deleteDir(VEnvironment.getDataAppPackageDirectory(pkg));
+					PackageCache.remove(pkg);
+					mBroadcastSystem.stopApp(pkg);
+				} catch (Exception e) {
+					e.printStackTrace();
+				} finally {
+					notifyAppUninstalled(pkg);
+				}
 				return true;
 			}
 		}


### PR DESCRIPTION
bug: 删除非最后一个应用，会删除该应用以及其后的那个应用.

两点：
1）当前代码里有两套机制删除，一处是里的PagerView.java的moveToCrash回调，一处是HomePresenterImpl.datachange机制。选择移除前者。

2）发现VAppManagerService.uninstallApp的mBroadcastSystem.stopApp(pkg);地方会抛出异常，如下，原因还不清楚，所以加了try catch捕获，确保notifyAppUninstalled(pkg);一定执行。
```
01-13 20:23:38.948 19332-19578/io.virtualapp:x W/System.err: java.lang.IllegalArgumentException: Receiver not registered: com.lody.virtual.service.am.StaticBroadcastSystem$StaticBroadcastReceiver@be80583
01-13 20:23:38.948 19332-19578/io.virtualapp:x W/System.err:     at android.app.LoadedApk.forgetReceiverDispatcher(LoadedApk.java:780)
01-13 20:23:38.948 19332-19578/io.virtualapp:x W/System.err:     at android.app.ContextImpl.unregisterReceiver(ContextImpl.java:1195)
01-13 20:23:38.948 19332-19578/io.virtualapp:x W/System.err:     at com.lody.virtual.service.am.StaticBroadcastSystem.stopApp(StaticBroadcastSystem.java:87)
01-13 20:23:38.949 19332-19578/io.virtualapp:x W/System.err:     at com.lody.virtual.service.pm.VAppManagerService.uninstallApp(VAppManagerService.java:211)
01-13 20:23:38.949 19332-19578/io.virtualapp:x W/System.err:     at com.lody.virtual.service.IAppManager$Stub.onTransact(IAppManager.java:91)
01-13 20:23:38.949 19332-19578/io.virtualapp:x W/System.err:     at android.os.Binder.execTransact(Binder.java:453)
```

