### PR TITLE
bringback "add suffix to VAClient's label in Overview Screen"

### DIFF
--- a/VirtualApp/lib/src/main/java/com/lody/virtual/client/hook/patchs/am/ActivityManagerPatch.java
+++ b/VirtualApp/lib/src/main/java/com/lody/virtual/client/hook/patchs/am/ActivityManagerPatch.java
@@ -48,7 +48,9 @@ import mirror.android.util.Singleton;
 		SetPackageAskScreenCompat.class, GetPackageAskScreenCompat.class,
 		CheckPermission.class, PublishContentProviders.class, GetCurrentUser.class,
 		UnstableProviderDied.class, GetCallingActivity.class, FinishActivity.class,
-		GetServices.class,})
+		GetServices.class,
+
+		SetTaskDescription.class,})
 
 public class ActivityManagerPatch extends PatchDelegate<HookDelegate<IInterface>> {
 

--- a/VirtualApp/lib/src/main/java/com/lody/virtual/client/hook/patchs/am/SetTaskDescription.java
+++ b/VirtualApp/lib/src/main/java/com/lody/virtual/client/hook/patchs/am/SetTaskDescription.java
@@ -1,0 +1,61 @@
+package com.lody.virtual.client.hook.patchs.am;
+
+import android.annotation.TargetApi;
+import android.app.ActivityManager;
+import android.app.Application;
+import android.graphics.Bitmap;
+import android.graphics.drawable.BitmapDrawable;
+import android.graphics.drawable.Drawable;
+import android.os.Build;
+import android.os.IBinder;
+
+import com.lody.virtual.client.VClientImpl;
+import com.lody.virtual.client.hook.base.Hook;
+
+import java.lang.reflect.Method;
+
+/**
+ * @author prife
+ *
+ * @see android.app.IActivityManager#setTaskDescription(IBinder token,
+ * 				ActivityManager.TaskDescription values)
+ */
+@TargetApi(Build.VERSION_CODES.LOLLIPOP)
+/* package */ class SetTaskDescription extends Hook {
+	static final String VACLIENT_SUFFIX = "[VA]";
+	@Override
+	public String getName() {
+		return "setTaskDescription";
+	}
+
+	@Override
+	public Object onHook(Object who, Method method, Object... args) throws Throwable {
+		ActivityManager.TaskDescription td = (ActivityManager.TaskDescription)args[1];
+
+		String label = td.getLabel();
+		Bitmap icon = td.getIcon();
+		if ((label == null || !label.endsWith(VACLIENT_SUFFIX)) || icon == null) {
+			Application app = VClientImpl.getClient().getCurrentApplication();
+			if (label == null) {
+				label = app.getApplicationInfo().loadLabel(app.getPackageManager()) + VACLIENT_SUFFIX;
+			} else {
+				label += VACLIENT_SUFFIX;
+			}
+
+			if (icon == null) {
+				Drawable drawable = app.getApplicationInfo().loadIcon(app.getPackageManager());
+				if (drawable instanceof BitmapDrawable) {
+					icon = ((BitmapDrawable) drawable).getBitmap();
+				}
+			}
+			args[1] = new ActivityManager.TaskDescription(label, icon, td.getPrimaryColor());
+		}
+
+		return method.invoke(who, args);
+	}
+
+	@Override
+	public boolean isEnable() {
+		return isAppProcess();
+	}
+}


### PR DESCRIPTION
This reverts commit 384a92b34e95d0237bf245c57520c0c78e4c9690.
and remove all usages of hide api, `TaskDescription.setLabel/setIcon`