### PR TITLE
Fix: launched apps share the same task in Overview screen

### DIFF
--- a/VirtualApp/lib/src/main/AndroidManifest.xml
+++ b/VirtualApp/lib/src/main/AndroidManifest.xml
@@ -252,7 +252,7 @@
             android:name="com.lody.virtual.client.stub.StubActivity$C0"
             android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
             android:process=":p0"
-            android:taskAffinity="com.lody.virtual.vt"
+            android:taskAffinity="com.lody.virtual.vt0"
             android:theme="@style/VATheme">
             <meta-data
                 android:name="X-Identity"
@@ -262,7 +262,7 @@
             android:name="com.lody.virtual.client.stub.StubActivity$C1"
             android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
             android:process=":p1"
-            android:taskAffinity="com.lody.virtual.vt"
+            android:taskAffinity="com.lody.virtual.vt1"
             android:theme="@style/VATheme">
             <meta-data
                 android:name="X-Identity"
@@ -272,7 +272,7 @@
             android:name="com.lody.virtual.client.stub.StubActivity$C2"
             android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
             android:process=":p2"
-            android:taskAffinity="com.lody.virtual.vt"
+            android:taskAffinity="com.lody.virtual.vt2"
             android:theme="@style/VATheme">
             <meta-data
                 android:name="X-Identity"
@@ -283,7 +283,7 @@
             android:name="com.lody.virtual.client.stub.StubActivity$C3"
             android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
             android:process=":p3"
-            android:taskAffinity="com.lody.virtual.vt"
+            android:taskAffinity="com.lody.virtual.vt3"
             android:theme="@style/VATheme">
             <meta-data
                 android:name="X-Identity"
@@ -294,7 +294,7 @@
             android:name="com.lody.virtual.client.stub.StubActivity$C4"
             android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
             android:process=":p4"
-            android:taskAffinity="com.lody.virtual.vt"
+            android:taskAffinity="com.lody.virtual.vt4"
             android:theme="@style/VATheme">
             <meta-data
                 android:name="X-Identity"
@@ -305,7 +305,7 @@
             android:name="com.lody.virtual.client.stub.StubActivity$C5"
             android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
             android:process=":p5"
-            android:taskAffinity="com.lody.virtual.vt"
+            android:taskAffinity="com.lody.virtual.vt5"
             android:theme="@style/VATheme">
             <meta-data
                 android:name="X-Identity"
@@ -316,7 +316,7 @@
             android:name="com.lody.virtual.client.stub.StubActivity$C6"
             android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
             android:process=":p6"
-            android:taskAffinity="com.lody.virtual.vt"
+            android:taskAffinity="com.lody.virtual.vt6"
             android:theme="@style/VATheme">
             <meta-data
                 android:name="X-Identity"
@@ -327,7 +327,7 @@
             android:name="com.lody.virtual.client.stub.StubActivity$C7"
             android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
             android:process=":p7"
-            android:taskAffinity="com.lody.virtual.vt">
+            android:taskAffinity="com.lody.virtual.vt7">
             <meta-data
                 android:name="X-Identity"
                 android:value="Stub-User"/>
@@ -337,7 +337,7 @@
             android:name="com.lody.virtual.client.stub.StubActivity$C8"
             android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
             android:process=":p8"
-            android:taskAffinity="com.lody.virtual.vt"
+            android:taskAffinity="com.lody.virtual.vt8"
             android:theme="@style/VATheme">
             <meta-data
                 android:name="X-Identity"
@@ -348,7 +348,7 @@
             android:name="com.lody.virtual.client.stub.StubActivity$C9"
             android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
             android:process=":p9"
-            android:taskAffinity="com.lody.virtual.vt"
+            android:taskAffinity="com.lody.virtual.vt9"
             android:theme="@style/VATheme">
             <meta-data
                 android:name="X-Identity"
@@ -360,7 +360,7 @@
             android:name="com.lody.virtual.client.stub.StubActivity$C10"
             android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
             android:process=":p10"
-            android:taskAffinity="com.lody.virtual.vt"
+            android:taskAffinity="com.lody.virtual.vt10"
             android:theme="@style/VATheme">
             <meta-data
                 android:name="X-Identity"
@@ -372,7 +372,7 @@
             android:name="com.lody.virtual.client.stub.StubActivity$C11"
             android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
             android:process=":p11"
-            android:taskAffinity="com.lody.virtual.vt"
+            android:taskAffinity="com.lody.virtual.vt11"
             android:theme="@style/VATheme">
             <meta-data
                 android:name="X-Identity"
@@ -384,7 +384,7 @@
             android:name="com.lody.virtual.client.stub.StubActivity$C12"
             android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
             android:process=":p12"
-            android:taskAffinity="com.lody.virtual.vt"
+            android:taskAffinity="com.lody.virtual.vt12"
             android:theme="@style/VATheme">
             <meta-data
                 android:name="X-Identity"
@@ -397,7 +397,7 @@
             android:name="com.lody.virtual.client.stub.StubActivity$C0_"
             android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
             android:process=":p0"
-            android:taskAffinity="com.lody.virtual.vt"
+            android:taskAffinity="com.lody.virtual.vt0"
             android:theme="@android:style/Theme.Dialog">
             <meta-data
                 android:name="X-Identity"
@@ -407,7 +407,7 @@
             android:name="com.lody.virtual.client.stub.StubActivity$C1_"
             android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
             android:process=":p1"
-            android:taskAffinity="com.lody.virtual.vt"
+            android:taskAffinity="com.lody.virtual.vt1"
             android:theme="@android:style/Theme.Dialog">
             <meta-data
                 android:name="X-Identity"
@@ -417,7 +417,7 @@
             android:name="com.lody.virtual.client.stub.StubActivity$C2_"
             android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
             android:process=":p2"
-            android:taskAffinity="com.lody.virtual.vt"
+            android:taskAffinity="com.lody.virtual.vt2"
             android:theme="@android:style/Theme.Dialog">
             <meta-data
                 android:name="X-Identity"
@@ -428,7 +428,7 @@
             android:name="com.lody.virtual.client.stub.StubActivity$C3_"
             android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
             android:process=":p3"
-            android:taskAffinity="com.lody.virtual.vt"
+            android:taskAffinity="com.lody.virtual.vt3"
             android:theme="@android:style/Theme.Dialog">
             <meta-data
                 android:name="X-Identity"
@@ -439,7 +439,7 @@
             android:name="com.lody.virtual.client.stub.StubActivity$C4_"
             android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
             android:process=":p4"
-            android:taskAffinity="com.lody.virtual.vt"
+            android:taskAffinity="com.lody.virtual.vt4"
             android:theme="@android:style/Theme.Dialog">
             <meta-data
                 android:name="X-Identity"
@@ -450,7 +450,7 @@
             android:name="com.lody.virtual.client.stub.StubActivity$C5_"
             android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
             android:process=":p5"
-            android:taskAffinity="com.lody.virtual.vt"
+            android:taskAffinity="com.lody.virtual.vt5"
             android:theme="@android:style/Theme.Dialog">
             <meta-data
                 android:name="X-Identity"
@@ -461,7 +461,7 @@
             android:name="com.lody.virtual.client.stub.StubActivity$C6_"
             android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
             android:process=":p6"
-            android:taskAffinity="com.lody.virtual.vt"
+            android:taskAffinity="com.lody.virtual.vt6"
             android:theme="@android:style/Theme.Dialog">
             <meta-data
                 android:name="X-Identity"
@@ -472,7 +472,7 @@
             android:name="com.lody.virtual.client.stub.StubActivity$C7_"
             android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
             android:process=":p7"
-            android:taskAffinity="com.lody.virtual.vt"
+            android:taskAffinity="com.lody.virtual.vt7"
             android:theme="@android:style/Theme.Dialog">
             <meta-data
                 android:name="X-Identity"
@@ -483,7 +483,7 @@
             android:name="com.lody.virtual.client.stub.StubActivity$C8_"
             android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
             android:process=":p8"
-            android:taskAffinity="com.lody.virtual.vt"
+            android:taskAffinity="com.lody.virtual.vt8"
             android:theme="@android:style/Theme.Dialog">
             <meta-data
                 android:name="X-Identity"
@@ -494,7 +494,7 @@
             android:name="com.lody.virtual.client.stub.StubActivity$C9_"
             android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
             android:process=":p9"
-            android:taskAffinity="com.lody.virtual.vt"
+            android:taskAffinity="com.lody.virtual.vt9"
             android:theme="@android:style/Theme.Dialog">
             <meta-data
                 android:name="X-Identity"
@@ -505,7 +505,7 @@
             android:name="com.lody.virtual.client.stub.StubActivity$C10_"
             android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
             android:process=":p10"
-            android:taskAffinity="com.lody.virtual.vt"
+            android:taskAffinity="com.lody.virtual.vt10"
             android:theme="@android:style/Theme.Dialog">
             <meta-data
                 android:name="X-Identity"
@@ -516,7 +516,7 @@
             android:name="com.lody.virtual.client.stub.StubActivity$C11_"
             android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
             android:process=":p11"
-            android:taskAffinity="com.lody.virtual.vt"
+            android:taskAffinity="com.lody.virtual.vt11"
             android:theme="@android:style/Theme.Dialog">
             <meta-data
                 android:name="X-Identity"
@@ -527,7 +527,7 @@
             android:name="com.lody.virtual.client.stub.StubActivity$C12_"
             android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"
             android:process=":p12"
-            android:taskAffinity="com.lody.virtual.vt"
+            android:taskAffinity="com.lody.virtual.vt12"
             android:theme="@android:style/Theme.Dialog">
             <meta-data
                 android:name="X-Identity"


### PR DESCRIPTION
Bug: new launched app in VA will replace the previous launched app in
Overview screen (also named `the recent app list`), so there is only
one VA app in Overview screen.