### PR TITLE
替换NetworkManagementService.setUidCleartextNetworkPolicy参数中的uid

### DIFF
--- a/VirtualApp/lib/src/main/java/com/lody/virtual/client/core/PatchManager.java
+++ b/VirtualApp/lib/src/main/java/com/lody/virtual/client/core/PatchManager.java
@@ -28,6 +28,7 @@ import com.lody.virtual.client.hook.patchs.location.LocationManagerPatch;
 import com.lody.virtual.client.hook.patchs.media.router.MediaRouterServicePatch;
 import com.lody.virtual.client.hook.patchs.media.session.SessionManagerPatch;
 import com.lody.virtual.client.hook.patchs.mount.MountServicePatch;
+import com.lody.virtual.client.hook.patchs.net_management.NetworkManagementPatch;
 import com.lody.virtual.client.hook.patchs.notification.NotificationManagerPatch;
 import com.lody.virtual.client.hook.patchs.persistent_data_block.PersistentDataBlockServicePatch;
 import com.lody.virtual.client.hook.patchs.phonesubinfo.PhoneSubInfoPatch;
@@ -52,6 +53,7 @@ import static android.os.Build.VERSION_CODES.JELLY_BEAN_MR2;
 import static android.os.Build.VERSION_CODES.KITKAT;
 import static android.os.Build.VERSION_CODES.LOLLIPOP;
 import static android.os.Build.VERSION_CODES.LOLLIPOP_MR1;
+import static android.os.Build.VERSION_CODES.M;
 
 /**
  * @author Lody
@@ -173,6 +175,9 @@ public final class PatchManager {
 			}
 			if (Build.VERSION.SDK_INT >= LOLLIPOP_MR1) {
 				addPatch(new GraphicsStatsPatch());
+			}
+			if (Build.VERSION.SDK_INT >= M) {
+				addPatch(new NetworkManagementPatch());
 			}
             addPatch(new ConnectivityPatch());
 		}

--- a/VirtualApp/lib/src/main/java/com/lody/virtual/client/hook/binders/NetworkManagementBinderDelegate.java
+++ b/VirtualApp/lib/src/main/java/com/lody/virtual/client/hook/binders/NetworkManagementBinderDelegate.java
@@ -1,0 +1,20 @@
+package com.lody.virtual.client.hook.binders;
+
+import android.os.IBinder;
+import android.os.IInterface;
+
+import com.lody.virtual.client.hook.base.HookBinderDelegate;
+
+import mirror.android.os.INetworkManagementService;
+import mirror.android.os.ServiceManager;
+
+public class NetworkManagementBinderDelegate extends HookBinderDelegate {
+
+	public static final String NETWORKMANAGEMENT_SERVICE = "network_management";
+
+	@Override
+	protected IInterface createInterface() {
+		IBinder binder = ServiceManager.getService.call(NETWORKMANAGEMENT_SERVICE);
+		return INetworkManagementService.Stub.asInterface.call(binder);
+	}
+}

--- a/VirtualApp/lib/src/main/java/com/lody/virtual/client/hook/patchs/net_management/NetworkManagementPatch.java
+++ b/VirtualApp/lib/src/main/java/com/lody/virtual/client/hook/patchs/net_management/NetworkManagementPatch.java
@@ -1,0 +1,35 @@
+package com.lody.virtual.client.hook.patchs.net_management;
+
+import android.annotation.TargetApi;
+import android.os.Build;
+
+import com.lody.virtual.client.hook.base.PatchDelegate;
+import com.lody.virtual.client.hook.base.ReplaceUidHook;
+import com.lody.virtual.client.hook.binders.NetworkManagementBinderDelegate;
+
+import mirror.android.os.ServiceManager;
+
+@TargetApi(Build.VERSION_CODES.M)
+public class NetworkManagementPatch extends PatchDelegate<NetworkManagementBinderDelegate> {
+
+	@Override
+	protected NetworkManagementBinderDelegate createHookDelegate() {
+		return new NetworkManagementBinderDelegate();
+	}
+
+	@Override
+	public void inject() throws Throwable {
+		getHookDelegate().replaceService(NetworkManagementBinderDelegate.NETWORKMANAGEMENT_SERVICE);
+	}
+
+	@Override
+	protected void onBindHooks() {
+		super.onBindHooks();
+		addHook(new ReplaceUidHook("setUidCleartextNetworkPolicy", 0));
+	}
+
+	@Override
+	public boolean isEnvBad() {
+		return getHookDelegate() != ServiceManager.getService.call(NetworkManagementBinderDelegate.NETWORKMANAGEMENT_SERVICE);
+	}
+}

--- a/VirtualApp/lib/src/main/java/mirror/android/os/INetworkManagementService.java
+++ b/VirtualApp/lib/src/main/java/mirror/android/os/INetworkManagementService.java
@@ -1,0 +1,18 @@
+package mirror.android.os;
+
+import android.os.IBinder;
+import android.os.IInterface;
+
+import mirror.MethodParams;
+import mirror.RefClass;
+import mirror.RefStaticMethod;
+
+public class INetworkManagementService {
+    public static Class<?> TYPE = RefClass.load(INetworkManagementService.class, "android.os.INetworkManagementService");
+
+    public static class Stub {
+        public static Class<?> TYPE = RefClass.load(Stub.class, "android.os.INetworkManagementService$Stub");
+        @MethodParams({IBinder.class})
+        public static RefStaticMethod<IInterface> asInterface;
+    }
+}


### PR DESCRIPTION
替换NetworkManagementService.setUidCleartextNetworkPolicy参数中的uid，解决Android6.0以上版本插件中调用StrictMode.setVmPolicy导致的异常