### PR TITLE
修复deletePackageLocked不能正确执行

### DIFF
--- a/VirtualApp/lib/src/main/java/com/lody/virtual/server/pm/PackageCache.java
+++ b/VirtualApp/lib/src/main/java/com/lody/virtual/server/pm/PackageCache.java
@@ -30,12 +30,8 @@ public class PackageCache {
 
 	public static PackageParser.Package remove(String packageName) {
 		synchronized (PackageCache.class) {
-			PackageParser.Package p = sPackageCaches.remove(packageName);
-			if (p != null) {
-				VPackageManagerService.get().deletePackageLocked(packageName);
-				return p;
-			}
-			return null;
+			VPackageManagerService.get().deletePackageLocked(packageName);
+			return sPackageCaches.remove(packageName);
 		}
 	}
 }


### PR DESCRIPTION
当sPackageCaches.remove移除包名后，deletePackageLocked就会因找不到包名而忽略执行，所以调整执行顺序