### PR TITLE
Populate ApplicationInfo.deviceXxxDataDir on Android N

### DIFF
--- a/VirtualApp/lib/src/main/java/com/lody/virtual/client/fixer/ComponentFixer.java
+++ b/VirtualApp/lib/src/main/java/com/lody/virtual/client/fixer/ComponentFixer.java
@@ -12,6 +12,7 @@ import com.lody.virtual.helper.utils.collection.ArrayMap;
 import com.lody.virtual.os.VEnvironment;
 
 import mirror.android.content.pm.ApplicationInfoL;
+import mirror.android.content.pm.ApplicationInfoN;
 
 /**
  * @author Lody
@@ -37,6 +38,10 @@ public class ComponentFixer {
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
 			ApplicationInfoL.scanSourceDir.set(applicationInfo, applicationInfo.dataDir);
 			ApplicationInfoL.scanPublicSourceDir.set(applicationInfo, applicationInfo.dataDir);
+		}
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+			ApplicationInfoN.deviceEncryptedDataDir.set(applicationInfo, applicationInfo.dataDir);
+			ApplicationInfoN.deviceProtectedDataDir.set(applicationInfo, applicationInfo.dataDir);
 		}
 		applicationInfo.enabled = true;
 		applicationInfo.nativeLibraryDir = setting.libPath;

--- a/VirtualApp/lib/src/main/java/mirror/android/content/pm/ApplicationInfoN.java
+++ b/VirtualApp/lib/src/main/java/mirror/android/content/pm/ApplicationInfoN.java
@@ -1,0 +1,12 @@
+package mirror.android.content.pm;
+
+import android.content.pm.ApplicationInfo;
+
+import mirror.RefClass;
+import mirror.RefObject;
+
+public class ApplicationInfoN {
+    public static Class<?> TYPE = RefClass.load(ApplicationInfoN.class, ApplicationInfo.class);
+    public static RefObject<String> deviceProtectedDataDir;
+    public static RefObject<String> deviceEncryptedDataDir;
+}


### PR DESCRIPTION
That's a beautiful piece of software, I'm learning a lot from it.
I'm making some refactoring and fixing random bugs in order to understand the project more deeply, feel free to ignore any patch you don't think is relevant.

In this particular patch, not having `ApplicationInfo.deviceEncryptedDataDir` and `ApplicationInfo.deviceProtectedDataDir` causes crashes on applications with flags `CONTEXT_DEVICE_PROTECTED_STORAGE` and `CONTEXT_CREDENTIAL_PROTECTED_STORAGE`.

I have no idea where these flags come from, but they are set on `com.google.android.gms.persist`, which pretty much makes any Google applications unusable on Android N (Although this is not the only problem)