### PR TITLE
Fix hook for IActivityManager.getRecentTasks on Android N

### DIFF
--- a/VirtualApp/lib/src/main/java/com/lody/virtual/client/hook/patchs/am/ActivityManagerPatch.java
+++ b/VirtualApp/lib/src/main/java/com/lody/virtual/client/hook/patchs/am/ActivityManagerPatch.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import mirror.android.app.ActivityManagerNative;
 import mirror.android.app.IActivityManager;
+import mirror.android.content.pm.ParceledListSlice;
 import mirror.android.os.ServiceManager;
 import mirror.android.util.Singleton;
 
@@ -111,7 +112,11 @@ public class ActivityManagerPatch extends PatchDelegate<HookDelegate<IInterface>
 				@Override
 				public Object call(Object who, Method method, Object... args) throws Throwable {
 					//noinspection unchecked
-					List<ActivityManager.RecentTaskInfo> infos = (List<ActivityManager.RecentTaskInfo>) method.invoke(who, args);
+					Object _infos = (List<ActivityManager.RecentTaskInfo>) method.invoke(who, args);
+					List<ActivityManager.RecentTaskInfo> infos =
+							_infos instanceof ParceledListSlice
+									? ParceledListSlice.getList.call(_infos)
+									: (List)_infos;
 					for (ActivityManager.RecentTaskInfo info : infos) {
 						AppTaskInfo taskInfo = VActivityManager.get().getTaskInfo(info.id);
 						if (taskInfo == null) {
@@ -124,7 +129,7 @@ public class ActivityManagerPatch extends PatchDelegate<HookDelegate<IInterface>
 						info.origActivity = taskInfo.baseActivity;
 						info.baseIntent = taskInfo.baseIntent;
 					}
-					return super.call(who, method, args);
+					return _infos;
 				}
 			});
 		}

--- a/VirtualApp/lib/src/main/java/mirror/android/content/pm/ParceledListSlice.java
+++ b/VirtualApp/lib/src/main/java/mirror/android/content/pm/ParceledListSlice.java
@@ -2,6 +2,8 @@ package mirror.android.content.pm;
 
 import android.os.Parcelable;
 
+import java.util.List;
+
 import mirror.RefClass;
 import mirror.RefConstructor;
 import mirror.RefMethod;
@@ -19,4 +21,5 @@ public class ParceledListSlice {
     public static RefMethod<Boolean> isLastSlice;
     public static RefMethod<Parcelable> populateList;
     public static RefMethod<Void> setLastSlice;
+    public static RefMethod<List<?>> getList;
 }


### PR DESCRIPTION
That's a beautiful piece of software, I'm learning a lot from it.
I'm making some refactoring and fixing random bugs in order to understand the project more deeply, feel free to ignore any patch you don't think is relevant.

I'm not sure how I triggered the error, but an app crashed because the return type of `IActivityManager.getRecentTasks` has changed on Android N.
