### PR TITLE
Populate encrypted/protected directories on ApplicationInfo on Android N

### DIFF
--- a/VirtualApp/lib/src/main/java/com/lody/virtual/client/fixer/ComponentFixer.java
+++ b/VirtualApp/lib/src/main/java/com/lody/virtual/client/fixer/ComponentFixer.java
@@ -12,6 +12,7 @@ import com.lody.virtual.helper.utils.collection.ArrayMap;
 import com.lody.virtual.os.VEnvironment;
 
 import mirror.android.content.pm.ApplicationInfoL;
+import mirror.android.content.pm.ApplicationInfoN;
 
 /**
  * @author Lody
@@ -37,6 +38,12 @@ public class ComponentFixer {
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
 			ApplicationInfoL.scanSourceDir.set(applicationInfo, applicationInfo.dataDir);
 			ApplicationInfoL.scanPublicSourceDir.set(applicationInfo, applicationInfo.dataDir);
+		}
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+			ApplicationInfoN.deviceEncryptedDataDir.set(applicationInfo, applicationInfo.dataDir);
+			ApplicationInfoN.deviceProtectedDataDir.set(applicationInfo, applicationInfo.dataDir);
+			ApplicationInfoN.credentialEncryptedDataDir.set(applicationInfo, applicationInfo.dataDir);
+			ApplicationInfoN.credentialProtectedDataDir.set(applicationInfo, applicationInfo.dataDir);
 		}
 		applicationInfo.enabled = true;
 		applicationInfo.nativeLibraryDir = setting.libPath;

--- a/VirtualApp/lib/src/main/java/mirror/android/content/pm/ApplicationInfoN.java
+++ b/VirtualApp/lib/src/main/java/mirror/android/content/pm/ApplicationInfoN.java
@@ -1,0 +1,14 @@
+package mirror.android.content.pm;
+
+import android.content.pm.ApplicationInfo;
+
+import mirror.RefClass;
+import mirror.RefObject;
+
+public class ApplicationInfoN {
+    public static Class<?> TYPE = RefClass.load(ApplicationInfoN.class, ApplicationInfo.class);
+    public static RefObject<String> deviceProtectedDataDir;
+    public static RefObject<String> deviceEncryptedDataDir;
+    public static RefObject<String> credentialProtectedDataDir;
+    public static RefObject<String> credentialEncryptedDataDir;
+}


### PR DESCRIPTION
Not having this attribute causes crashes on `com.google.android.gms.persist`

I have no idea where the flags to enable encrypted/protected directories come from, but they are set on `com.google.android.gms.persist`, which pretty much makes any Google applications unusable on Android N (Although fixing this problem is not enough to have them working properly)
