### PR TITLE
Better support for installing apps from storage on new android releases

### DIFF
--- a/VirtualApp/app/src/main/java/io/virtualapp/home/ListAppActivity.java
+++ b/VirtualApp/app/src/main/java/io/virtualapp/home/ListAppActivity.java
@@ -1,9 +1,14 @@
 package io.virtualapp.home;
 
+import android.Manifest;
 import android.app.Activity;
 import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.os.Build;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.view.PagerTabStrip;
 import android.support.v4.view.ViewPager;
@@ -39,6 +44,11 @@ public class ListAppActivity extends VActivity {
 		mPagerTabStrip = (PagerTabStrip) findViewById(R.id.app_pager_tap_strip);
 		mPagerTabStrip.setTabIndicatorColor(ContextCompat.getColor(this, R.color.colorAccent));
 		mViewPager.setAdapter(new AppPagerAdapter(getSupportFragmentManager()));
+
+		// Request permission to access external storage
+		if (ActivityCompat.checkSelfPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
+			ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.READ_EXTERNAL_STORAGE}, 0);
+		}
 	}
 
 	private void setupActionBar(ActionBar actionBar) {
@@ -56,5 +66,15 @@ public class ListAppActivity extends VActivity {
 			return true;
 		}
 		return super.onOptionsItemSelected(item);
+	}
+
+	@Override
+	public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+		for (int result : grantResults) {
+			if (result == PackageManager.PERMISSION_GRANTED) {
+				mViewPager.setAdapter(new AppPagerAdapter(getSupportFragmentManager()));
+				break;
+			}
+		}
 	}
 }

--- a/VirtualApp/app/src/main/java/io/virtualapp/home/ListAppContract.java
+++ b/VirtualApp/app/src/main/java/io/virtualapp/home/ListAppContract.java
@@ -11,9 +11,6 @@ import io.virtualapp.home.models.AppModel;
  * @version 1.0
  */
 public class ListAppContract {
-	public static final int SELECT_APP_FROM_SYSTEM = 0;
-	public static final int SELECT_APP_FROM_SD_CARD = 1;
-
 	interface ListAppView extends BaseView<ListAppPresenter> {
 
 		void startLoading();

--- a/VirtualApp/app/src/main/java/io/virtualapp/home/ListAppFragment.java
+++ b/VirtualApp/app/src/main/java/io/virtualapp/home/ListAppFragment.java
@@ -1,5 +1,6 @@
 package io.virtualapp.home;
 
+import java.io.File;
 import java.util.List;
 
 import android.os.Bundle;
@@ -27,20 +28,24 @@ public class ListAppFragment extends VFragment<ListAppContract.ListAppPresenter>
 	private ProgressBar mProgressBar;
 	private AppListAdapter mAdapter;
 
-	public static ListAppFragment newInstance(int selectFrom) {
+	public static ListAppFragment newInstance(File selectFrom) {
 		Bundle args = new Bundle();
-		args.putInt(KEY_SELECT_FROM, selectFrom);
+		if (selectFrom != null)
+			args.putString(KEY_SELECT_FROM, selectFrom.getPath());
 		ListAppFragment fragment = new ListAppFragment();
 		fragment.setArguments(args);
 		return fragment;
 	}
 
-	private int getSelectFrom() {
-		int selectFrom = ListAppContract.SELECT_APP_FROM_SYSTEM;
+	private File getSelectFrom() {
 		Bundle bundle = getArguments();
-		if (bundle != null)
-			selectFrom = bundle.getInt(KEY_SELECT_FROM, selectFrom);
-		return selectFrom;
+		if (bundle != null) {
+			String selectFrom = bundle.getString(KEY_SELECT_FROM);
+			if (selectFrom != null) {
+				return new File(selectFrom);
+			}
+		}
+		return null;
 	}
 
 	@Nullable

--- a/VirtualApp/app/src/main/java/io/virtualapp/home/ListAppPresenterImpl.java
+++ b/VirtualApp/app/src/main/java/io/virtualapp/home/ListAppPresenterImpl.java
@@ -3,6 +3,8 @@ package io.virtualapp.home;
 import android.app.Activity;
 import android.content.Intent;
 
+import java.io.File;
+
 import io.virtualapp.VCommends;
 import io.virtualapp.home.models.AppDataSource;
 import io.virtualapp.home.models.AppModel;
@@ -17,9 +19,9 @@ public class ListAppPresenterImpl implements ListAppContract.ListAppPresenter {
 	private ListAppContract.ListAppView mView;
 	private AppDataSource mRepository;
 
-	private int from;
+	private File from;
 
-	public ListAppPresenterImpl(Activity activity, ListAppContract.ListAppView view, int fromWhere) {
+	public ListAppPresenterImpl(Activity activity, ListAppContract.ListAppView view, File fromWhere) {
 		mActivity = activity;
 		mView = view;
 		mRepository = new AppRepository(activity);
@@ -31,10 +33,10 @@ public class ListAppPresenterImpl implements ListAppContract.ListAppPresenter {
 	public void start() {
 		mView.setPresenter(this);
 		mView.startLoading();
-		if (from == ListAppContract.SELECT_APP_FROM_SYSTEM)
+		if (from == null)
 			mRepository.getInstalledApps(mActivity).done(mView::loadFinish);
 		else
-			mRepository.getSdCardApps(mActivity).done(mView::loadFinish);
+			mRepository.getStorageApps(mActivity, from).done(mView::loadFinish);
 	}
 
 	@Override

--- a/VirtualApp/app/src/main/java/io/virtualapp/home/adapters/AppPagerAdapter.java
+++ b/VirtualApp/app/src/main/java/io/virtualapp/home/adapters/AppPagerAdapter.java
@@ -1,9 +1,20 @@
 package io.virtualapp.home.adapters;
 
+import android.content.Context;
+import android.os.Build;
+import android.os.Environment;
+import android.os.storage.StorageManager;
+import android.os.storage.StorageVolume;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentPagerAdapter;
 
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import io.virtualapp.VApp;
+import io.virtualapp.abs.reflect.Reflect;
 import io.virtualapp.home.ListAppContract;
 import io.virtualapp.home.ListAppFragment;
 
@@ -12,31 +23,49 @@ import io.virtualapp.home.ListAppFragment;
  */
 
 public class AppPagerAdapter extends FragmentPagerAdapter {
-	private static String[] TITLES = {"系统", "SD卡"};
+	private List<String> titles = new ArrayList<>();
+	private List<File> dirs = new ArrayList<>();
 
 	public AppPagerAdapter(FragmentManager fm) {
 		super(fm);
+		titles.add("System");
+		dirs.add(null);
+
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+			Context ctx = VApp.getApp();
+			StorageManager storage = (StorageManager)ctx.getSystemService(Context.STORAGE_SERVICE);
+			for (StorageVolume volume : storage.getStorageVolumes()) {
+				//Why the fuck are getPathFile and getUserLabel hidden?!
+				//StorageVolume is kinda useless without those...
+				File dir = (File)Reflect.on(volume).call("getPathFile").get();
+				String label = Reflect.on(volume).call("getUserLabel").get();
+				if (dir.listFiles() != null) {
+					titles.add(label);
+					dirs.add(dir);
+				}
+			}
+		} else {
+			// Fallback: only support the default storage sources
+			File storageFir = Environment.getExternalStorageDirectory();
+			if (storageFir.list() != null) {
+				titles.add("Storage");
+				dirs.add(storageFir);
+			}
+		}
 	}
 
 	@Override
 	public Fragment getItem(int position) {
-		switch (position) {
-			case 0 :
-				return ListAppFragment.newInstance(ListAppContract.SELECT_APP_FROM_SYSTEM);
-			case 1 :
-				return ListAppFragment.newInstance(ListAppContract.SELECT_APP_FROM_SD_CARD);
-
-		}
-		return null;
+		return ListAppFragment.newInstance(dirs.get(position));
 	}
 
 	@Override
 	public int getCount() {
-		return TITLES.length;
+		return titles.size();
 	}
 
 	@Override
 	public CharSequence getPageTitle(int position) {
-		return TITLES[position];
+		return titles.get(position);
 	}
 }

--- a/VirtualApp/app/src/main/java/io/virtualapp/home/models/AppDataSource.java
+++ b/VirtualApp/app/src/main/java/io/virtualapp/home/models/AppDataSource.java
@@ -1,5 +1,6 @@
 package io.virtualapp.home.models;
 
+import java.io.File;
 import java.util.List;
 
 import org.jdeferred.Promise;
@@ -24,7 +25,7 @@ public interface AppDataSource {
 	 */
 	Promise<List<AppModel>, Throwable, Void> getInstalledApps(Context context);
 
-	Promise<List<AppModel>, Throwable, Void> getSdCardApps(Context context);
+	Promise<List<AppModel>, Throwable, Void> getStorageApps(Context context, File rootDir);
 
 	void addVirtualApp(AppModel app) throws Throwable;
 

--- a/VirtualApp/app/src/main/java/io/virtualapp/home/models/AppRepository.java
+++ b/VirtualApp/app/src/main/java/io/virtualapp/home/models/AppRepository.java
@@ -15,6 +15,7 @@ import org.jdeferred.Promise;
 import java.io.File;
 import java.text.Collator;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -27,20 +28,15 @@ import io.virtualapp.abs.ui.VUiKit;
 public class AppRepository implements AppDataSource {
 
 	private static final Collator COLLATOR = Collator.getInstance(Locale.CHINA);
-	private static List<String> sdCardScanPaths = new ArrayList<>();
-
-	static {
-		String sdCardPath = Environment.getExternalStorageDirectory().getAbsolutePath();
-		sdCardScanPaths.add(sdCardPath);
-		sdCardScanPaths.add(sdCardPath + File.separator + "wandoujia" + File.separator + "app");
-		sdCardScanPaths
-				.add(sdCardPath + File.separator + "tencent" + File.separator + "tassistant" + File.separator + "apk");
-		sdCardScanPaths.add(sdCardPath + File.separator + "BaiduAsa9103056");
-		sdCardScanPaths.add(sdCardPath + File.separator + "360Download");
-		sdCardScanPaths.add(sdCardPath + File.separator + "pp/downloader");
-		sdCardScanPaths.add(sdCardPath + File.separator + "pp/downloader/apk");
-		sdCardScanPaths.add(sdCardPath + File.separator + "pp/downloader/silent/apk");
-	}
+	private static final List<String> sdCardScanPaths = Arrays.asList(
+			".",
+			"wandoujia/app",
+			"tencent/tassistant/apk",
+			"BaiduAsa9103056",
+			"360Download",
+			"pp/downloader",
+			"pp/downloader/apk",
+			"pp/downloader/silent/apk");
 
 	private Context mContext;
 
@@ -75,18 +71,18 @@ public class AppRepository implements AppDataSource {
 	}
 
 	@Override
-	public Promise<List<AppModel>, Throwable, Void> getSdCardApps(Context context) {
+	public Promise<List<AppModel>, Throwable, Void> getStorageApps(Context context, File rootDir) {
 		return VUiKit.defer().when(() -> {
-			return pkgInfosToAppModels(context, findAndParseAPKs(context, sdCardScanPaths), false);
+			return pkgInfosToAppModels(context, findAndParseAPKs(context, rootDir, sdCardScanPaths), false);
 		});
 	}
 
-	private List<PackageInfo> findAndParseAPKs(Context context, List<String> paths) {
+	private List<PackageInfo> findAndParseAPKs(Context context, File rootDir, List<String> paths) {
 		List<PackageInfo> pkgs = new ArrayList<>();
 		if (paths == null)
 			return pkgs;
 		for (String path : paths) {
-			File[] dirFiles = new File(path).listFiles();
+			File[] dirFiles = new File(rootDir, path).listFiles();
 			if (dirFiles == null)
 				continue;
 			for (File f : dirFiles) {

--- a/VirtualApp/app/src/main/java/io/virtualapp/home/models/AppRepository.java
+++ b/VirtualApp/app/src/main/java/io/virtualapp/home/models/AppRepository.java
@@ -81,15 +81,15 @@ public class AppRepository implements AppDataSource {
 		});
 	}
 
-	private List<PackageInfo> findAndParseAPKs(Context context, List<String> pathes) {
+	private List<PackageInfo> findAndParseAPKs(Context context, List<String> paths) {
 		List<PackageInfo> pkgs = new ArrayList<>();
-		if (pathes == null)
+		if (paths == null)
 			return pkgs;
-		for (String path : pathes) {
-			File dir = new File(path);
-			if (!dir.exists() || !dir.isDirectory())
+		for (String path : paths) {
+			File[] dirFiles = new File(path).listFiles();
+			if (dirFiles == null)
 				continue;
-			for (File f : dir.listFiles()) {
+			for (File f : dirFiles) {
 				if (!f.getName().toLowerCase().endsWith(".apk"))
 					continue;
 				PackageInfo pkgInfo = null;


### PR DESCRIPTION
On new android versions (api 23 and up) the permission to read from the SD card must be obtained on runtime via `Activity.requestPermissions()`

These patches ensure that the permission is requested, and that no error is thrown if it is not granted.

Also, it now uses `StorageManager.getStorageVolumes()` to list all storage locations instead of only the default one.