### PR TITLE
Move stub initialization to VirtualCore.startup()

### DIFF
--- a/VirtualApp/app/src/main/java/io/virtualapp/VApp.java
+++ b/VirtualApp/app/src/main/java/io/virtualapp/VApp.java
@@ -45,8 +45,6 @@ public class VApp extends Application {
 
     @Override
     protected void attachBaseContext(Context base) {
-        StubManifest.STUB_CP_AUTHORITY = BuildConfig.APPLICATION_ID + "." + StubManifest.STUB_DEF_AUTHORITY;
-        ServiceManagerNative.SERVICE_CP_AUTH = BuildConfig.APPLICATION_ID + "." + ServiceManagerNative.SERVICE_DEF_AUTH;
         super.attachBaseContext(base);
         try {
             VirtualCore.get().startup(base);

--- a/VirtualApp/lib/src/main/java/com/lody/virtual/client/core/VirtualCore.java
+++ b/VirtualApp/lib/src/main/java/com/lody/virtual/client/core/VirtualCore.java
@@ -28,6 +28,7 @@ import com.lody.virtual.client.ipc.LocalProxyUtils;
 import com.lody.virtual.client.ipc.VActivityManager;
 import com.lody.virtual.client.ipc.VPackageManager;
 import com.lody.virtual.client.ipc.ServiceManagerNative;
+import com.lody.virtual.client.stub.StubManifest;
 import com.lody.virtual.helper.compat.BundleCompat;
 import com.lody.virtual.helper.proto.AppSetting;
 import com.lody.virtual.helper.proto.InstallResult;
@@ -149,6 +150,8 @@ public final class VirtualCore {
 			if (Looper.myLooper() != Looper.getMainLooper()) {
 				throw new IllegalStateException("VirtualCore.startup() must called in main thread.");
 			}
+			StubManifest.STUB_CP_AUTHORITY = context.getPackageName() + "." + StubManifest.STUB_DEF_AUTHORITY;
+			ServiceManagerNative.SERVICE_CP_AUTH = context.getPackageName() + "." + ServiceManagerNative.SERVICE_DEF_AUTH;
 			this.context = context;
 			mainThread = ActivityThread.currentActivityThread.call();
 			unHookPackageManager = context.getPackageManager();


### PR DESCRIPTION
I feel like initializing `StubManifest.STUB_CP_AUTHORITY` and `ServiceManagerNative.SERVICE_CP_AUTH` fits VirtualCore.startup() better