### PR TITLE
Moved task description customization to a delegate

### DIFF
--- a/VirtualApp/app/src/main/java/io/virtualapp/MyTaskDescriptionDelegate.java
+++ b/VirtualApp/app/src/main/java/io/virtualapp/MyTaskDescriptionDelegate.java
@@ -1,0 +1,28 @@
+package io.virtualapp;
+
+import android.annotation.TargetApi;
+import android.app.ActivityManager;
+import android.os.Build;
+
+import com.lody.virtual.client.hook.delegate.PhoneInfoDelegate;
+import com.lody.virtual.client.hook.delegate.TaskDescriptionDelegate;
+import com.lody.virtual.os.VUserManager;
+
+
+/**
+ * Patch the task description with the (Virtual) user name
+ */
+@TargetApi(Build.VERSION_CODES.LOLLIPOP)
+class MyTaskDescriptionDelegate implements TaskDescriptionDelegate {
+    @Override
+    public ActivityManager.TaskDescription getTaskDescription(ActivityManager.TaskDescription oldTaskDescription) {
+        String laberPrefix = "["+ VUserManager.get().getUserName()+"] ";
+
+        if (!oldTaskDescription.getLabel().startsWith(laberPrefix)) {
+            // Is it really necessary?
+            return new ActivityManager.TaskDescription(laberPrefix + oldTaskDescription.getLabel(), oldTaskDescription.getIcon(), oldTaskDescription.getPrimaryColor());
+        } else {
+            return oldTaskDescription;
+        }
+    }
+}

--- a/VirtualApp/app/src/main/java/io/virtualapp/VApp.java
+++ b/VirtualApp/app/src/main/java/io/virtualapp/VApp.java
@@ -46,6 +46,7 @@ public class VApp extends Application {
         } else if (VirtualCore.get().isVAppProcess()) {
             VirtualCore.get().setComponentDelegate(new MyComponentDelegate());
             VirtualCore.get().setPhoneInfoDelegate(new MyPhoneInfoDelegate());
+            VirtualCore.get().setTaskDescriptionDelegate(new MyTaskDescriptionDelegate());
         }
     }
 

--- a/VirtualApp/lib/src/main/java/com/lody/virtual/client/core/VirtualCore.java
+++ b/VirtualApp/lib/src/main/java/com/lody/virtual/client/core/VirtualCore.java
@@ -24,6 +24,7 @@ import com.lody.virtual.client.env.VirtualRuntime;
 import com.lody.virtual.client.fixer.ContextFixer;
 import com.lody.virtual.client.hook.delegate.ComponentDelegate;
 import com.lody.virtual.client.hook.delegate.PhoneInfoDelegate;
+import com.lody.virtual.client.hook.delegate.TaskDescriptionDelegate;
 import com.lody.virtual.client.ipc.LocalProxyUtils;
 import com.lody.virtual.client.ipc.VActivityManager;
 import com.lody.virtual.client.ipc.VPackageManager;
@@ -80,6 +81,7 @@ public final class VirtualCore {
 	private ConditionVariable initLock = new ConditionVariable();
 	private PhoneInfoDelegate phoneInfoDelegate;
 	private ComponentDelegate componentDelegate;
+	private TaskDescriptionDelegate taskDescriptionDelegate;
 
 	public ConditionVariable getInitLock() {
 		return initLock;
@@ -109,6 +111,14 @@ public final class VirtualCore {
 
 	public PhoneInfoDelegate getPhoneInfoDelegate() {
 		return phoneInfoDelegate;
+	}
+
+	public void setTaskDescriptionDelegate(TaskDescriptionDelegate taskDescriptionDelegate) {
+		this.taskDescriptionDelegate = taskDescriptionDelegate;
+	}
+
+	public TaskDescriptionDelegate getTaskDescriptionDelegate() {
+		return taskDescriptionDelegate;
 	}
 
 	public static VirtualCore get() {

--- a/VirtualApp/lib/src/main/java/com/lody/virtual/client/hook/delegate/TaskDescriptionDelegate.java
+++ b/VirtualApp/lib/src/main/java/com/lody/virtual/client/hook/delegate/TaskDescriptionDelegate.java
@@ -1,0 +1,10 @@
+package com.lody.virtual.client.hook.delegate;
+
+import android.annotation.TargetApi;
+import android.app.Activity;
+import android.app.ActivityManager;
+import android.os.Build;
+
+public interface TaskDescriptionDelegate {
+    public ActivityManager.TaskDescription getTaskDescription(ActivityManager.TaskDescription oldTaskDescription);
+}


### PR DESCRIPTION
This allows the frontend to customize label and icon of each activity, rather than using a predefined "[User] Label" customization