### PR TITLE
Fix: WifiManagerPatch FC: MacAddress may be null

### DIFF
--- a/VirtualApp/lib/src/main/java/com/lody/virtual/client/hook/patchs/wifi/WifiManagerPatch.java
+++ b/VirtualApp/lib/src/main/java/com/lody/virtual/client/hook/patchs/wifi/WifiManagerPatch.java
@@ -31,7 +31,7 @@ public class WifiManagerPatch extends PatchBinderDelegate {
 			public Object call(Object who, Method method, Object... args) throws Throwable {
 				WifiInfo info = (WifiInfo) super.call(who, method, args);
 				if (info != null) {
-					if (info.getMacAddress() == null || info.getMacAddress().startsWith("00-00-00-00-00-00")) {
+					if (info.getMacAddress() != null && info.getMacAddress().startsWith("00-00-00-00-00-00")) {
 						Reflect.on(info).set("mMacAddress", "00:00:08:76:54:32");
 					}
 				}

--- a/VirtualApp/lib/src/main/java/com/lody/virtual/client/hook/patchs/wifi/WifiManagerPatch.java
+++ b/VirtualApp/lib/src/main/java/com/lody/virtual/client/hook/patchs/wifi/WifiManagerPatch.java
@@ -31,7 +31,7 @@ public class WifiManagerPatch extends PatchBinderDelegate {
 			public Object call(Object who, Method method, Object... args) throws Throwable {
 				WifiInfo info = (WifiInfo) super.call(who, method, args);
 				if (info != null) {
-					if (info.getMacAddress().startsWith("00-00-00-00-00-00")) {
+					if (info.getMacAddress() == null || info.getMacAddress().startsWith("00-00-00-00-00-00")) {
 						Reflect.on(info).set("mMacAddress", "00:00:08:76:54:32");
 					}
 				}


### PR DESCRIPTION
一些设备上getMacAddress返回是null，于是调用startsWith就闪退了。我加了一个简单的判断逻辑来避免这个问题。。。