### PR TITLE
return null when activities is empty

### DIFF
--- a/VirtualApp/lib/src/main/java/com/lody/virtual/server/am/TaskRecord.java
+++ b/VirtualApp/lib/src/main/java/com/lody/virtual/server/am/TaskRecord.java
@@ -29,7 +29,10 @@ class TaskRecord {
 
     AppTaskInfo getAppTaskInfo() {
         int len = activities.size();
-        ComponentName top = len > 0 ? activities.get(len - 1).component : null;
+        if (len <= 0) {
+            return null;
+        }
+        ComponentName top = activities.get(len - 1).component;
         return new AppTaskInfo(taskId, taskRoot, taskRoot.getComponent(), top);
     }
 


### PR DESCRIPTION
guest app will assume topActivity as Not Null (which is the default behavior framework does)
while remove all members from group and exit talk session in wechat , it gets runningTasks and report its topActivity to server, which crash the app,


besides, all callers of getAppTaskInfo take care of null process as i reviewed, so its safe to return null here

