### PR TITLE
add AudioRecord#native_check_permission(packagename) hook for vivo

### DIFF
--- a/VirtualApp/lib/src/main/java/com/lody/virtual/client/NativeEngine.java
+++ b/VirtualApp/lib/src/main/java/com/lody/virtual/client/NativeEngine.java
@@ -1,6 +1,7 @@
 package com.lody.virtual.client;
 
 import android.hardware.Camera;
+import android.media.AudioRecord;
 import android.os.Binder;
 import android.os.Build;
 import android.os.Process;
@@ -32,6 +33,7 @@ public class NativeEngine {
     private static Method gOpenDexFileNative;
     private static Method gCameraNativeSetup;
     private static int gCameraMethodType;
+    private static Method gAudioRecordNativeCheckPermission;
 
     static {
         try {
@@ -94,6 +96,14 @@ public class NativeEngine {
         if (gCameraNativeSetup != null) {
             gCameraNativeSetup.setAccessible(true);
         }
+
+        for (Method mth : AudioRecord.class.getDeclaredMethods()) {
+            if (mth.getName().equals("native_check_permission") && mth.getParameterTypes().length == 1 && mth.getParameterTypes()[0] == String.class) {
+                gAudioRecordNativeCheckPermission = mth;
+                mth.setAccessible(true);
+                break;
+            }
+        }
     }
 
     public static void startDexOverride() {
@@ -143,7 +153,7 @@ public class NativeEngine {
     }
 
     public static void hookNative() {
-        Method[] methods = {gOpenDexFileNative, gCameraNativeSetup};
+        Method[] methods = {gOpenDexFileNative, gCameraNativeSetup, gAudioRecordNativeCheckPermission};
         try {
             nativeHookNative(methods, VirtualCore.get().getHostPkg(), VirtualRuntime.isArt(), Build.VERSION.SDK_INT, gCameraMethodType);
         } catch (Throwable e) {

--- a/VirtualApp/lib/src/main/jni/Foundation/VMPatch.h
+++ b/VirtualApp/lib/src/main/jni/Foundation/VMPatch.h
@@ -15,7 +15,7 @@
 #include "Helper.h"
 
 enum METHODS {
-    OPEN_DEX = 0, CAMERA_SETUP
+    OPEN_DEX = 0, CAMERA_SETUP, VIVO_AUDIORECORD_NATIVE_CHECK_PERMISSION
 };
 
 void patchAndroidVM(jobjectArray javaMethods, jstring packageName, jboolean isArt, jint apiLevel, jint cameraMethodType);


### PR DESCRIPTION
wechat voice message is N/A in vivo (Funtouch OS_2.5 android 5.0.2),
vivo add a special jni interface for voice permission check(AudioRecord#native_check_permission)
and the package should be passed as the host package 