### PR TITLE
fix first start activity with flag=0x24000000

### DIFF
--- a/VirtualApp/lib/src/main/java/com/lody/virtual/server/am/ActivityStack.java
+++ b/VirtualApp/lib/src/main/java/com/lody/virtual/server/am/ActivityStack.java
@@ -327,7 +327,7 @@ import static android.content.pm.ActivityInfo.LAUNCH_SINGLE_TOP;
                     deliverNewIntentLocked(sourceRecord, topRecord, intent);
                     delivered = true;
                 }
-                if (isClearTop_SingleTop) {
+                if (isClearTop_SingleTop && hasActivity(topRecord, intent.getComponent())) {
                     topRecord.marked = false;
                     deliverNewIntentLocked(sourceRecord, topRecord, intent);
                     delivered = true;
@@ -612,6 +612,14 @@ import static android.content.pm.ActivityInfo.LAUNCH_SINGLE_TOP;
         }
     }
 
+    private boolean hasActivity(ActivityRecord topRecord, ComponentName component) {
+        for (ActivityRecord ar : topRecord.task.activities) {
+            if (component.equals(ar.component)) {
+                return true;
+            }
+        }
+        return false;
+    }
 
     private enum ClearTarget {
         NOTHING,


### PR DESCRIPTION
发现一个问题，首次启动这个singletop+cleartop的activity时 不会调启动，现在加上一个过滤条件， 如果您那边有更好的简便算法可以替代 hasActivity()这个方法  这个需要紧急修复。