### PR TITLE
StubManifest: Fix use of 'final' modifier

### DIFF
--- a/VirtualApp/lib/src/main/java/com/lody/virtual/client/stub/StubManifest.java
+++ b/VirtualApp/lib/src/main/java/com/lody/virtual/client/stub/StubManifest.java
@@ -8,13 +8,13 @@ import java.util.Locale;
 
 public class StubManifest {
     public static final String STUB_DEF_AUTHORITY = "virtual_stub_";
-    public static String STUB_ACTIVITY = StubActivity.class.getName();
-    public static String STUB_DIALOG = StubDialog.class.getName();
-    public static String STUB_CP = StubContentProvider.class.getName();
-    public static String STUB_JOB = StubJob.class.getName();
-    public static String RESOLVER_ACTIVITY = ResolverActivity.class.getName();
+    public static final String STUB_ACTIVITY = StubActivity.class.getName();
+    public static final String STUB_DIALOG = StubDialog.class.getName();
+    public static final String STUB_CP = StubContentProvider.class.getName();
+    public static final String STUB_JOB = StubJob.class.getName();
+    public static final String RESOLVER_ACTIVITY = ResolverActivity.class.getName();
     public static String STUB_CP_AUTHORITY = "virtual_stub_";
-    public static int STUB_COUNT = 50;
+    public static final int STUB_COUNT = 50;
 
     /**
      * If enable,

--- a/VirtualApp/lib/src/main/java/com/lody/virtual/client/stub/StubManifest.java
+++ b/VirtualApp/lib/src/main/java/com/lody/virtual/client/stub/StubManifest.java
@@ -8,7 +8,6 @@ import java.util.Locale;
 
 public class StubManifest {
     public static final String STUB_DEF_AUTHORITY = "virtual_stub_";
-    public static final boolean ENABLE_GMS = false;
     public static String STUB_ACTIVITY = StubActivity.class.getName();
     public static String STUB_DIALOG = StubDialog.class.getName();
     public static String STUB_CP = StubContentProvider.class.getName();
@@ -16,6 +15,12 @@ public class StubManifest {
     public static String RESOLVER_ACTIVITY = ResolverActivity.class.getName();
     public static String STUB_CP_AUTHORITY = "virtual_stub_";
     public static int STUB_COUNT = 50;
+
+    /**
+     * If enable,
+     * GMS and related google packages available on the host are automatically installed on VirtualApp.
+     */
+    public static boolean ENABLE_GMS = false;
 
     /**
      * If enable,


### PR DESCRIPTION
ENABLE_GMS should be configurable by the app, therefore not final.

All the other STUB_xx constants, on the other hand, should be final