### PR TITLE
Log package and process names on launch

### DIFF
--- a/VirtualApp/lib/src/main/java/com/lody/virtual/client/VClientImpl.java
+++ b/VirtualApp/lib/src/main/java/com/lody/virtual/client/VClientImpl.java
@@ -23,6 +23,7 @@ import android.os.Message;
 import android.os.Process;
 import android.os.RemoteException;
 import android.os.StrictMode;
+import android.util.Log;
 
 import com.lody.virtual.client.core.CrashHandler;
 import com.lody.virtual.client.core.InvocationStubManager;
@@ -230,6 +231,7 @@ public final class VClientImpl extends IVClient.Stub {
         data.appInfo = VPackageManager.get().getApplicationInfo(packageName, 0, getUserId(vuid));
         data.processName = processName;
         data.providers = VPackageManager.get().queryContentProviders(processName, getVUid(), PackageManager.GET_META_DATA);
+        Log.i(TAG, "Binding application " + data.appInfo.packageName + " (" + data.processName + ")");
         mBoundApplication = data;
         VirtualRuntime.setupRuntime(data.processName, data.appInfo);
         Runtime.getRuntime().addShutdownHook(new Thread() {


### PR DESCRIPTION
When running on AndroidStudio, AndroidMonitor often reads the name of a new process before VirtualApp renames it.
Which means the process list has virtualapp:p0, virtualapp:p1, etc -- Not very useful!

To make debugging easier, the packageName and processName are now one of the first things logged.

I find it useful :)