### PR TITLE
Created a new Annotation, @LogInvocation, to help with debugging.

### DIFF
--- a/VirtualApp/lib/src/main/java/com/lody/virtual/client/hook/base/LogInvocation.java
+++ b/VirtualApp/lib/src/main/java/com/lody/virtual/client/hook/base/LogInvocation.java
@@ -1,0 +1,56 @@
+package com.lody.virtual.client.hook.base;
+
+import android.util.Log;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Add this annotation to a {@link MethodProxy} or a {@link MethodInvocationStub} to
+ * log all the calls and their arguments.
+ *
+ * Obviously, this is only useful for debugging.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LogInvocation {
+    public Condition value() default Condition.ALWAYS;
+
+    static enum Condition {
+        /** Never logs anything */
+        NEVER {
+            public int getLogLevel(boolean isHooked, boolean isError) {
+                return -1;
+            }
+        },
+        /**
+         * Logs every call.
+         * Mostly useful for debugging.
+         */
+        ALWAYS {
+            public int getLogLevel(boolean isHooked, boolean isError) {
+                return isError ? Log.WARN : Log.INFO;
+            }
+        },
+        /**
+         * Logs only calls that exited with error
+         * A reasonable tradeoff between noise and getting relevant information
+         */
+        ON_ERROR {
+            public int getLogLevel(boolean isHooked, boolean isError) {
+                return isError ? Log.WARN : -1;
+            }
+        },
+
+        /**
+         *  Log only calls that haven't been hooked
+         *  It only makes sense on a MethodInvocationProxy, and is useful to pinpoint missing methods
+         */
+        NOT_HOOKED {
+            public int getLogLevel(boolean isHooked, boolean isError) {
+                return isHooked ? -1 : isError ? Log.WARN : Log.INFO;
+            }
+        };
+
+        public abstract int getLogLevel(boolean isHooked, boolean isError);
+    };
+};

--- a/VirtualApp/lib/src/main/java/com/lody/virtual/client/hook/base/MethodInvocationProxy.java
+++ b/VirtualApp/lib/src/main/java/com/lody/virtual/client/hook/base/MethodInvocationProxy.java
@@ -30,6 +30,11 @@ public abstract class MethodInvocationProxy<T extends MethodInvocationStub> impl
         this.mInvocationStub = invocationStub;
         onBindMethods();
         afterHookApply(invocationStub);
+
+        LogInvocation loggingAnnotation = getClass().getAnnotation(LogInvocation.class);
+        if (loggingAnnotation != null) {
+            invocationStub.setInvocationLoggingCondition(loggingAnnotation.value());
+        }
     }
 
     protected void onBindMethods() {

--- a/VirtualApp/lib/src/main/java/com/lody/virtual/client/hook/base/MethodProxy.java
+++ b/VirtualApp/lib/src/main/java/com/lody/virtual/client/hook/base/MethodProxy.java
@@ -17,6 +17,14 @@ import java.lang.reflect.Method;
 public abstract class MethodProxy {
 
     private boolean enable = true;
+    private LogInvocation.Condition mInvocationLoggingCondition = LogInvocation.Condition.NEVER; // Inherit
+
+    public MethodProxy() {
+        LogInvocation loggingAnnotation = getClass().getAnnotation(LogInvocation.class);
+        if (loggingAnnotation != null) {
+            this.mInvocationLoggingCondition = loggingAnnotation.value();
+        }
+    }
 
     public static String getHostPkg() {
         return VirtualCore.get().getHostPkg();
@@ -80,6 +88,14 @@ public abstract class MethodProxy {
 
     public void setEnable(boolean enable) {
         this.enable = enable;
+    }
+
+    public LogInvocation.Condition getInvocationLoggingCondition() {
+        return mInvocationLoggingCondition;
+    }
+
+    public void setInvocationloggingCondition(LogInvocation.Condition invocationLoggingCondition) {
+        mInvocationLoggingCondition = invocationLoggingCondition;
     }
 
     public boolean isAppPkg(String pkg) {


### PR DESCRIPTION
Just annotate a MethodProxy or MethodInvocationStub subclass with it and all the related invocations will be shown in the logs :)

It is also possible to only log invocations that throw exceptions, or invocations to unhooked methods.