### PR TITLE
Remove confusing and artificial error stack on process termination

### DIFF
--- a/VirtualApp/lib/src/main/java/com/lody/virtual/client/VClientImpl.java
+++ b/VirtualApp/lib/src/main/java/com/lody/virtual/client/VClientImpl.java
@@ -232,13 +232,6 @@ public final class VClientImpl extends IVClient.Stub {
         data.providers = VPackageManager.get().queryContentProviders(processName, getVUid(), PackageManager.GET_META_DATA);
         mBoundApplication = data;
         VirtualRuntime.setupRuntime(data.processName, data.appInfo);
-        Runtime.getRuntime().addShutdownHook(new Thread() {
-            @Override
-            public synchronized void start() {
-                new Exception().printStackTrace();
-                super.start();
-            }
-        });
         int targetSdkVersion = data.appInfo.targetSdkVersion;
         if (targetSdkVersion < Build.VERSION_CODES.GINGERBREAD) {
             StrictMode.ThreadPolicy newPolicy = new StrictMode.ThreadPolicy.Builder(StrictMode.getThreadPolicy()).permitNetwork().build();


### PR DESCRIPTION
Whenever a process quits, it currently looks like it crashed.

But no, it sometimes is a clean exit.