### PR TITLE
fixing file name for substrate x86 header

### DIFF
--- a/VirtualApp/lib/src/main/jni/Substrate/SubstrateHook.cpp
+++ b/VirtualApp/lib/src/main/jni/Substrate/SubstrateHook.cpp
@@ -703,7 +703,7 @@ static size_t SubstrateHookFunction(SubstrateProcessRef process, void *symbol, v
 
 #if defined(__i386__) || defined(__x86_64__)
 
-#include "Substratex86.hpp"
+#include "SubstrateX86.hpp"
 
 static size_t MSGetInstructionWidthIntel(void *start) {
     hde64s decode;


### PR DESCRIPTION
The name of the header file was incorrectly typed.