### PR TITLE
using sysconf(_SC_PAGESIZE) instead of getpagesize

### DIFF
--- a/VirtualApp/lib/src/main/jni/Substrate/SubstratePosixMemory.cpp
+++ b/VirtualApp/lib/src/main/jni/Substrate/SubstratePosixMemory.cpp
@@ -51,7 +51,7 @@ extern "C" SubstrateMemoryRef SubstrateMemoryCreate(SubstrateAllocatorRef alloca
     if (size == 0)
         return NULL;
 
-    int page(getpagesize());
+    long page(sysconf(_SC_PAGESIZE)); // Portable applications should employ sysconf(_SC_PAGESIZE) instead of getpagesize
 
     uintptr_t base(reinterpret_cast<uintptr_t>(data) / page * page);
     size_t width(((reinterpret_cast<uintptr_t>(data) + size - 1) / page + 1) * page - base);


### PR DESCRIPTION
Portable applications should employ sysconf(_SC_PAGESIZE) instead of getpagesize as some systems may fail to link getpagesize dynamiclly, see http://www.man7.org/linux/man-pages/man2/getpagesize.2.html