### PR TITLE
fix  IContentProvider.delete() parameter error after API18

### DIFF
--- a/VirtualApp/lib/src/main/java/com/lody/virtual/client/hook/providers/ProviderHook.java
+++ b/VirtualApp/lib/src/main/java/com/lody/virtual/client/hook/providers/ProviderHook.java
@@ -160,7 +160,7 @@ public class ProviderHook implements InvocationHandler {
             } else if ("getType".equals(name)) {
                 return getType(methodBox, (Uri) args[0]);
             } else if ("delete".equals(name)) {
-                Uri url = (Uri) args[0];
+                Uri url = (Uri) args[start];
                 String selection = (String) args[start + 1];
                 String[] selectionArgs = (String[]) args[start + 2];
                 return delete(methodBox, url, selection, selectionArgs);


### PR DESCRIPTION
崩溃信息如下：
java.lang.ClassCastException: java.lang.String cannot be cast to android.net.Uri
                                                                    at com.lody.virtual.client.hook.providers.ProviderHook.invoke(ProviderHook.java:164)
                                                                    at java.lang.reflect.Proxy.invoke(Proxy.java:393)
                                                                    at $Proxy42.delete(Unknown Source)
                                                                    at android.content.ContentResolver.delete(ContentResolver.java:1356)
                                                                    at com.android.calendar.event.EventUtils.deleteCalendar(EventUtils.java:153)
                                                                    at com.miui.calendar.holiday.HolidayService.clearHolidayCalendars(HolidayService.java:154)
                                                                    at com.miui.calendar.holiday.HolidayService.syncHoliday(HolidayService.java:83)
                                                                    at com.miui.calendar.holiday.HolidayService.onHandleIntent(HolidayService.java:57)
                                                                    at android.app.IntentService$ServiceHandler.handleMessage(IntentService.java:66)
                                                                    at android.os.Handler.dispatchMessage(Handler.java:102)
                                                                    at android.os.Looper.loop(Looper.java:157)
                                                                    at android.os.HandlerThread.run(HandlerThread.java:61)