### PR TITLE
修复jobservice 的一个bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,76 +1,16 @@
-[![VA banner](https://raw.githubusercontent.com/asLody/VirtualApp/master/Logo.png)](https://github.com/asLody/VirtualApp)
+[![Build Status](https://travis-ci.org/android-hacker/VirtualXposed.svg?branch=exposed)](https://travis-ci.org/android-hacker/VirtualXposed)
 
-[中国人猛戳这里](CHINESE.md "中文")
-
-About
+简介
 -----
-**VirtualApp** is an open platform for Android that allows you to create a `Virtual Space`,
-you can install and run apk inside. Beyond that, VirtualApp is also a `Plugin Framework`,
-the plugins running on VirtualApp does not require any constraints.
-VirtualApp does **not** require root, it is running on the `local process`.
+本项目是在[VirtualApp](https://github.com/asLody/VirtualApp) 的基础上再次开发的，适配了一些在使用过程中出现的bug。
 
-NOTICE
+警告
 -------
-**This project has been authorized by the business.**
+本项目使用的 VirtualApp 不允许用于商业用途，如果有这个需求，请联系 Lody (imlody@foxmail.com)。
 
-**You are not allowed to modify the app module and put to the software market, if you do that, The consequences you know :)**
-
-**VirtualApp is not free, If you need to use the lib code, please send email to me :)**
-
-Background
+使用
 ----------
 
-VirtualApp was born in early 2015, Originally, it is just a simple plugin framework, 
-But as time goes on,
-the compatibility of it is getting better and better.
-in the end, it evolved into a `Virtual Container`.
+[猛戳这里](CHINESE.md "中文")
 
 
-Get started
------------
-If you use latest android studio (version 2.0 or above), please disable `Instant Run`.
-Open `Setting | Build,Exception,Deployment`, and disable `Enable Instant Run to hot swap...`
-
-**Goto your Application and insert the following code:**
-```java
-    @Override
-    protected void attachBaseContext(Context base) {
-        super.attachBaseContext(base);
-        try {
-            VirtualCore.get().startup(base);
-        } catch (Throwable e) {
-            e.printStackTrace();
-        }
-    }
-```
-
-**Install a virtual App:**
-```java
-    VirtualCore.get().installPackage({APK PATH}, flags);
-    
-```
-
-**Launch a virtual App:**
-```java
-    //VirtualApp support multi-user-mode which can run multiple instances of a same app.
-    //if you don't need this feature, just set `{userId}` to 0.
-    Intent intent = VirtualCore.get().getLaunchIntent({PackageName}, {userId});
-    VActivityManager.get().startActivity(intent, {userId});
-```
-
-**Uninstall a virtual App:**
-```java
-    VirtualCore.get().uninstallPackage({PackageName});
-```
-
-More details, please read the source code of demo app, :-)
-
-Documentation
--------------
-
-VirtualApp currently has **no documentation**, If you are interested in VirtualApp, please send email to me.
-
-Contact us
-------------
-
-    zl@aluohe.com

--- a/README.md
+++ b/README.md
@@ -6,11 +6,50 @@
 
 警告
 -------
-本项目使用的 VirtualApp 不允许用于商业用途，如果有这个需求，请联系 Lody (imlody@foxmail.com)。
+本项目使用的 VirtualApp 不允许用于商业用途，如果有这个需求，请联系 Lody (zl@aluohe.com)。
 
 使用
 ----------
 
 [猛戳这里](CHINESE.md "中文")
 
+使用说明
+----------
 
+**前往你的Application并添加如下代码:**
+
+```java
+    @Override
+    protected void attachBaseContext(Context base) {
+        super.attachBaseContext(base);
+        try {
+            VirtualCore.getCore().startup(base);
+        } catch (Throwable e) {
+            e.printStackTrace();
+        }
+    }
+```
+
+**安装App:**
+
+```java
+    VirtualCore.getCore().installApp({APK PATH}, flags);
+```
+
+**启动App:**
+
+```java
+    VirtualCore.getCore().launchApp({PackageName});
+```
+
+**移除App:**
+
+```java
+    VirtualCore.getCore().uninstallApp({PackageName});
+```
+
+**该App的基本信息:**
+
+```java
+    VirtualCore.getCore().findApp({PackageName});
+```

--- a/VirtualApp/app/build.gradle
+++ b/VirtualApp/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 
 android {
-    compileSdkVersion 25
+    compileSdkVersion 26
     buildToolsVersion '26.0.2'
     defaultConfig {
         applicationId "io.virtualapp"

--- a/VirtualApp/lib/build.gradle
+++ b/VirtualApp/lib/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 24
+    compileSdkVersion 26
     buildToolsVersion '26.0.2'
 
     defaultConfig {

--- a/VirtualApp/lib/src/main/java/com/lody/virtual/client/hook/proxies/job/JobServiceStub.java
+++ b/VirtualApp/lib/src/main/java/com/lody/virtual/client/hook/proxies/job/JobServiceStub.java
@@ -3,91 +3,142 @@ package com.lody.virtual.client.hook.proxies.job;
 import android.annotation.TargetApi;
 import android.app.job.JobInfo;
 import android.content.Context;
+import android.content.Intent;
 import android.os.Build;
+import android.os.Build.VERSION;
 
 import com.lody.virtual.client.hook.base.MethodProxy;
 import com.lody.virtual.client.hook.base.BinderInvocationProxy;
 import com.lody.virtual.client.ipc.VJobScheduler;
+import com.lody.virtual.helper.utils.ComponentUtils;
 
 import java.lang.reflect.Method;
 
 import mirror.android.app.job.IJobScheduler;
+import mirror.android.app.job.JobWorkItem;
 
 /**
  * @author Lody
- *
  * @see android.app.job.JobScheduler
  */
 @TargetApi(Build.VERSION_CODES.LOLLIPOP)
 public class JobServiceStub extends BinderInvocationProxy {
 
-	public JobServiceStub() {
-		super(IJobScheduler.Stub.asInterface, Context.JOB_SCHEDULER_SERVICE);
-	}
+    public JobServiceStub() {
+        super(IJobScheduler.Stub.asInterface, Context.JOB_SCHEDULER_SERVICE);
+    }
 
-	@Override
-	protected void onBindMethods() {
-		super.onBindMethods();
-		addMethodProxy(new schedule());
-		addMethodProxy(new getAllPendingJobs());
-		addMethodProxy(new cancelAll());
-		addMethodProxy(new cancel());
-	}
+    @Override
+    protected void onBindMethods() {
+        super.onBindMethods();
+        addMethodProxy(new schedule());
+        addMethodProxy(new getAllPendingJobs());
+        addMethodProxy(new cancelAll());
+        addMethodProxy(new cancel());
+
+        if (VERSION.SDK_INT >= 24) {
+            addMethodProxy(new getPendingJob());
+        }
+        if (VERSION.SDK_INT >= 26) {
+            addMethodProxy(new enqueue());
+        }
+    }
 
 
-	private class schedule extends MethodProxy {
+    private class schedule extends MethodProxy {
 
-		@Override
-		public String getMethodName() {
-			return "schedule";
-		}
+        @Override
+        public String getMethodName() {
+            return "schedule";
+        }
 
-		@Override
-		public Object call(Object who, Method method, Object... args) throws Throwable {
-			JobInfo jobInfo = (JobInfo) args[0];
-			return VJobScheduler.get().schedule(jobInfo);
-		}
-	}
+        @Override
+        public Object call(Object who, Method method, Object... args) throws Throwable {
+            JobInfo jobInfo = (JobInfo) args[0];
+            return VJobScheduler.get().schedule(jobInfo);
+        }
+    }
 
-	private class getAllPendingJobs extends MethodProxy {
+    private class getAllPendingJobs extends MethodProxy {
 
-		@Override
-		public String getMethodName() {
-			return "getAllPendingJobs";
-		}
+        @Override
+        public String getMethodName() {
+            return "getAllPendingJobs";
+        }
 
-		@Override
-		public Object call(Object who, Method method, Object... args) throws Throwable {
-			return VJobScheduler.get().getAllPendingJobs();
-		}
-	}
+        @Override
+        public Object call(Object who, Method method, Object... args) throws Throwable {
+            return VJobScheduler.get().getAllPendingJobs();
+        }
+    }
 
-	private class cancelAll extends MethodProxy {
+    private class cancelAll extends MethodProxy {
 
-		@Override
-		public String getMethodName() {
-			return "cancelAll";
-		}
+        @Override
+        public String getMethodName() {
+            return "cancelAll";
+        }
 
-		@Override
-		public Object call(Object who, Method method, Object... args) throws Throwable {
-			VJobScheduler.get().cancelAll();
-			return 0;
-		}
-	}
+        @Override
+        public Object call(Object who, Method method, Object... args) throws Throwable {
+            VJobScheduler.get().cancelAll();
+            return 0;
+        }
+    }
 
-	private class cancel extends MethodProxy {
+    private class cancel extends MethodProxy {
 
-		@Override
-		public String getMethodName() {
-			return "cancel";
-		}
+        @Override
+        public String getMethodName() {
+            return "cancel";
+        }
 
-		@Override
-		public Object call(Object who, Method method, Object... args) throws Throwable {
-			int jobId = (int) args[0];
-			VJobScheduler.get().cancel(jobId);
-			return 0;
-		}
-	}
+        @Override
+        public Object call(Object who, Method method, Object... args) throws Throwable {
+            int jobId = (int) args[0];
+            VJobScheduler.get().cancel(jobId);
+            return 0;
+        }
+    }
+
+    private class getPendingJob extends MethodProxy {
+        private getPendingJob() {
+        }
+
+        public Object call(Object who, Method method, Object... args) throws Throwable {
+            return VJobScheduler.get().getPendingJob((Integer) args[0]);
+        }
+
+        public String getMethodName() {
+            return "getPendingJob";
+        }
+    }
+
+    private class enqueue extends MethodProxy {
+        private enqueue() {
+        }
+
+        public Object call(Object who, Method method, Object... args) throws Throwable {
+            return VJobScheduler.get().enqueue(
+                    (JobInfo) args[0],
+                    JobServiceStub.this.redirect(args[1], MethodProxy.getAppPkg())
+            );
+        }
+
+        public String getMethodName() {
+            return "enqueue";
+        }
+    }
+
+    private Object redirect(Object item, String pkg) {
+        if (item == null) {
+            return null;
+        }
+        Intent redirectIntentSender = ComponentUtils.redirectIntentSender(4, pkg, (Intent) JobWorkItem.getIntent.call(item, new Object[0]), null);
+        Object newInstance = JobWorkItem.ctor.newInstance(redirectIntentSender);
+        JobWorkItem.mWorkId.set(newInstance, JobWorkItem.mWorkId.get(item));
+        JobWorkItem.mGrants.set(newInstance, JobWorkItem.mGrants.get(item));
+        JobWorkItem.mDeliveryCount.set(newInstance, JobWorkItem.mDeliveryCount.get(item));
+        return newInstance;
+    }
 }

--- a/VirtualApp/lib/src/main/java/com/lody/virtual/client/ipc/VJobScheduler.java
+++ b/VirtualApp/lib/src/main/java/com/lody/virtual/client/ipc/VJobScheduler.java
@@ -1,6 +1,7 @@
 package com.lody.virtual.client.ipc;
 
 import android.app.job.JobInfo;
+import android.os.Parcelable;
 import android.os.RemoteException;
 
 import com.lody.virtual.client.env.VirtualRuntime;
@@ -56,6 +57,27 @@ public class VJobScheduler {
             getService().cancel(jobId);
         } catch (RemoteException e) {
             e.printStackTrace();
+        }
+    }
+
+
+    public JobInfo getPendingJob(int jobId) {
+        try {
+            return getService().getPendingJob(jobId);
+        } catch (RemoteException e) {
+            return (JobInfo) VirtualRuntime.crash(e);
+        }
+    }
+
+
+    public int enqueue(JobInfo job, Object workItem) {
+        if (workItem == null) {
+            return -1;
+        }
+        try {
+            return getService().enqueue(job, (Parcelable) workItem);
+        } catch (RemoteException e) {
+            return (Integer) VirtualRuntime.crash(e);
         }
     }
 }

--- a/VirtualApp/lib/src/main/java/com/lody/virtual/client/stub/StubJob.java
+++ b/VirtualApp/lib/src/main/java/com/lody/virtual/client/stub/StubJob.java
@@ -12,6 +12,7 @@ import android.content.ServiceConnection;
 import android.os.Build;
 import android.os.IBinder;
 import android.os.RemoteException;
+import android.util.Log;
 
 import com.lody.virtual.client.core.InvocationStubManager;
 import com.lody.virtual.client.hook.proxies.am.ActivityManagerStub;
@@ -109,6 +110,8 @@ public class StubJob extends Service {
         super.onCreate();
         InvocationStubManager.getInstance().checkEnv(ActivityManagerStub.class);
         mScheduler = (JobScheduler) getSystemService(JOB_SCHEDULER_SERVICE);
+
+        Log.d("Q_M", "StubJob-->onCreate");
     }
 
     @Override

--- a/VirtualApp/lib/src/main/java/com/lody/virtual/client/stub/VASettings.java
+++ b/VirtualApp/lib/src/main/java/com/lody/virtual/client/stub/VASettings.java
@@ -21,6 +21,16 @@ public class VASettings {
     };
 
     /**
+     * 是否禁止插件应用直接调用返回桌面的 intent
+     * <p>
+     * Intent home = new Intent(Intent.ACTION_MAIN);
+     * home.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+     * home.addCategory(Intent.CATEGORY_HOME);
+     * startActivity(home);
+     */
+    public static boolean INTERCEPT_BACK_HOME = true;
+
+    /**
      * If enable,
      * App run in VA will allowed to create shortcut on your Desktop.
      */

--- a/VirtualApp/lib/src/main/java/com/lody/virtual/helper/utils/ComponentUtils.java
+++ b/VirtualApp/lib/src/main/java/com/lody/virtual/helper/utils/ComponentUtils.java
@@ -9,7 +9,15 @@ import android.content.pm.ComponentInfo;
 import com.lody.virtual.client.core.VirtualCore;
 import com.lody.virtual.client.env.SpecialComponentList;
 import com.lody.virtual.GmsSupport;
+import com.lody.virtual.client.ipc.VActivityManager;
+import com.lody.virtual.client.stub.StubPendingActivity;
+import com.lody.virtual.client.stub.StubPendingReceiver;
+import com.lody.virtual.client.stub.StubPendingService;
 import com.lody.virtual.helper.compat.ObjectsCompat;
+import com.lody.virtual.os.VUserHandle;
+
+import android.os.IBinder;
+import android.os.Parcelable;
 
 import static android.content.pm.ActivityInfo.LAUNCH_SINGLE_INSTANCE;
 
@@ -126,5 +134,45 @@ public class ComponentUtils {
             }
         }
         return newIntent;
+    }
+
+
+    public static Intent redirectIntentSender(int type, String creator, Intent intent, IBinder iBinder) {
+        Intent cloneFilter = intent.cloneFilter();
+        switch (type) {
+            case 1:
+                cloneFilter.setClass(VirtualCore.get().getContext(), StubPendingReceiver.class);
+                break;
+            case 2:
+                if (VirtualCore.get().resolveActivityInfo(intent, VUserHandle.myUserId()) != null) {
+                    cloneFilter.setClass(VirtualCore.get().getContext(), StubPendingActivity.class);
+                    cloneFilter.setFlags(intent.getFlags());
+                    if (iBinder != null) {
+                        try {
+                            Parcelable activityForToken = VActivityManager.get().getActivityForToken(iBinder);
+                            if (activityForToken != null) {
+                                cloneFilter.putExtra("_VA_|_caller_", activityForToken);
+                                break;
+                            }
+                        } catch (Throwable th) {
+                            break;
+                        }
+                    }
+                }
+                break;
+            case 4:
+                if (VirtualCore.get().resolveServiceInfo(intent, VUserHandle.myUserId()) != null) {
+                    cloneFilter.setClass(VirtualCore.get().getContext(), StubPendingService.class);
+                    break;
+                }
+                break;
+            default:
+                return null;
+        }
+        cloneFilter.putExtra("_VA_|_user_id_", VUserHandle.myUserId());
+        cloneFilter.putExtra("_VA_|_intent_", intent);
+        cloneFilter.putExtra("_VA_|_creator_", creator);
+        cloneFilter.putExtra("_VA_|_from_inner_", true);
+        return cloneFilter;
     }
 }

--- a/VirtualApp/lib/src/main/java/com/lody/virtual/server/BinderProvider.java
+++ b/VirtualApp/lib/src/main/java/com/lody/virtual/server/BinderProvider.java
@@ -22,6 +22,7 @@ import com.lody.virtual.server.interfaces.IAccountManager;
 import com.lody.virtual.server.interfaces.IActivityManager;
 import com.lody.virtual.server.interfaces.IAppManager;
 import com.lody.virtual.server.interfaces.IDeviceInfoManager;
+import com.lody.virtual.server.interfaces.IJobService;
 import com.lody.virtual.server.interfaces.INotificationManager;
 import com.lody.virtual.server.interfaces.IPackageManager;
 import com.lody.virtual.server.interfaces.IServiceFetcher;
@@ -61,7 +62,7 @@ public final class BinderProvider extends ContentProvider {
         IPCBus.register(IAppManager.class, VAppManagerService.get());
         BroadcastSystem.attach(VActivityManagerService.get(), VAppManagerService.get());
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            IPCBus.register(IJobScheduler.class, VJobSchedulerService.get());
+            IPCBus.register(IJobService.class, VJobSchedulerService.get());
         }
         VNotificationManagerService.systemReady(context);
         IPCBus.register(INotificationManager.class, VNotificationManagerService.get());

--- a/VirtualApp/lib/src/main/java/com/lody/virtual/server/interfaces/IJobService.java
+++ b/VirtualApp/lib/src/main/java/com/lody/virtual/server/interfaces/IJobService.java
@@ -1,6 +1,7 @@
 package com.lody.virtual.server.interfaces;
 
 import android.app.job.JobInfo;
+import android.os.Parcelable;
 import android.os.RemoteException;
 
 import java.util.List;
@@ -17,4 +18,8 @@ public interface IJobService {
     void cancelAll() throws RemoteException;
 
     List<JobInfo> getAllPendingJobs() throws RemoteException;
+
+    int enqueue(JobInfo jobInfo, Parcelable parcelable) throws RemoteException;
+
+    JobInfo getPendingJob(int i) throws RemoteException;
 }

--- a/VirtualApp/lib/src/main/java/com/lody/virtual/server/pm/VPackageManagerService.java
+++ b/VirtualApp/lib/src/main/java/com/lody/virtual/server/pm/VPackageManagerService.java
@@ -400,13 +400,16 @@ public class VPackageManagerService implements IPackageManager {
                 // If we have saved a preference for a preferred activity for
                 // this Intent, use that.
 
+                //从候选列表中查找一个最合适的，如果候选列表没有最合适的返回null
+                //然后从系统中查找合适的打开intent
                 ResolveInfo ri = findPreferredActivity(intent, resolvedType,
                         flags, query, r0.priority);
                 //noinspection ConstantConditions
                 if (ri != null) {
                     return ri;
                 }
-                return query.get(0);
+
+                return null;
             }
         }
         return null;
@@ -420,9 +423,10 @@ public class VPackageManagerService implements IPackageManager {
             return (ResolveInfo) method.invoke(null, intent, resolvedType, flags, query, priority);
         } catch (Exception e) {
             e.printStackTrace();
+            return query.get(0);
         }
 
-        return null;
+//        return null;
     }
 
 

--- a/VirtualApp/lib/src/main/java/com/lody/virtual/server/pm/VPackageManagerService.java
+++ b/VirtualApp/lib/src/main/java/com/lody/virtual/server/pm/VPackageManagerService.java
@@ -31,6 +31,8 @@ import com.lody.virtual.server.pm.parser.VPackage;
 
 import java.io.File;
 import java.io.PrintWriter;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -411,8 +413,18 @@ public class VPackageManagerService implements IPackageManager {
     }
 
     private ResolveInfo findPreferredActivity(Intent intent, String resolvedType, int flags, List<ResolveInfo> query, int priority) {
+
+        try {
+            Class clazz = Class.forName("com.virtual.helper.VALibHelper");
+            Method method = clazz.getDeclaredMethod("findPreferredActivity", Intent.class, String.class, int.class, List.class, int.class);
+            return (ResolveInfo) method.invoke(null, intent, resolvedType, flags, query, priority);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
         return null;
     }
+
 
     @Override
     public List<ResolveInfo> queryIntentActivities(Intent intent, String resolvedType, int flags, int userId) {

--- a/VirtualApp/lib/src/main/java/mirror/android/app/job/JobWorkItem.java
+++ b/VirtualApp/lib/src/main/java/mirror/android/app/job/JobWorkItem.java
@@ -1,0 +1,21 @@
+package mirror.android.app.job;
+
+import android.annotation.TargetApi;
+import android.content.Intent;
+import mirror.MethodParams;
+import mirror.RefClass;
+import mirror.RefConstructor;
+import mirror.RefInt;
+import mirror.RefMethod;
+import mirror.RefObject;
+
+@TargetApi(26)
+public class JobWorkItem {
+    public static Class<?> TYPE = RefClass.load(JobWorkItem.class, android.app.job.JobWorkItem.class);
+    @MethodParams({Intent.class})
+    public static RefConstructor<Object> ctor;
+    public static RefMethod<Intent> getIntent;
+    public static RefInt mDeliveryCount;
+    public static RefObject<Object> mGrants;
+    public static RefInt mWorkId;
+}


### PR DESCRIPTION
在最开始的  `com.lody.virtual.server.BinderProvider` 这个类的地65行,是这么注册这个映射关系的如下：
```
        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
            //这里是 IJobScheduler 的类名做的键 和VJobSchedulerService对象做值 的映射
            IPCBus.register(IJobScheduler.class, VJobSchedulerService.get());
        }
```

但是在`com.lody.virtual.client.ipc.VJobScheduler` 这个里面取的时候，发现映射关系找不到，继续查找发现，在第21行，有如下代码：
```
//这个里面的取映射关系的时候用的键是 IJobService.class 类的类名
 private IPCSingleton<IJobService> singleton = new IPCSingleton<>(IJobService.class);

```
这就会导致插件在使用JobService的时候，会出现空指针异常，进而崩溃，我现在的疑问是修改哪里的键合适。目前如果修改BinderProvider 这个类里面注册的对应关系的话，可以正常运行。